### PR TITLE
Fix/console errors

### DIFF
--- a/hiatus/src/Components/InteractiveMap/InteractiveMap.jsx
+++ b/hiatus/src/Components/InteractiveMap/InteractiveMap.jsx
@@ -6,15 +6,7 @@ import {Parser} from 'html-to-react'
 // var map = { __html: __html };
 
 const rawHTML =
-`<head>
-<meta http-equiv="content-type" content="text/html; charset=UTF-8">
-
-</head>
-<body>
-<h1>Access to Abortion by State</h1>
-<p>Hover over each state to see where abortion care is accessible legally and safely. <br />Click on a state to learn more about their policies regarding abortion care.</p>
-<div id="map"></div>
-</body>`
+`<div id="map"></div>`
 
 function InteractiveMap() {
   let navigate = useNavigate()

--- a/hiatus/src/Pages/Stories/Stories.jsx
+++ b/hiatus/src/Pages/Stories/Stories.jsx
@@ -35,11 +35,15 @@ function Stories() {
       <Card id="banner">
       <Card.Img src="https://i.imgur.com/DJnLxtx.png" alt="women supporting women" />
       <Card.ImgOverlay>
-        <Card.Text className="caption">
-          <h3>Our Stories Matter</h3><br />
-          <h4>Our hope is for you to read these stories and <br />
-        feel comforted by the fact that you are not alone.</h4>
+        <Card.Body className='caption'>
+        <Card.Header as='h3'>
+          Our Stories Matter
+        </Card.Header>
+        <Card.Text as='h4'>
+        Our hope is for you to read these stories and <br />
+        feel comforted by the fact that you are not alone.
         </Card.Text>
+        </Card.Body>
       </Card.ImgOverlay>
     </Card>
    

--- a/hiatus/src/Pages/Stories/Stories.jsx
+++ b/hiatus/src/Pages/Stories/Stories.jsx
@@ -48,8 +48,8 @@ function Stories() {
       {storyData
       ? storyData.map((story, index) => {
           return(
-            <Col id="columns">
-              <Card id="card" key={index}>
+            <Col id="columns" key={index}>
+              <Card id="card">
                 <Card.Body>
                   <Card.Title>{story.title}</Card.Title>
                   {selected === index


### PR DESCRIPTION
Fixed some of the non-breaking error messages given in the console. Two involving stories and one involving the interactive map. The story map function was using the key in a child component of the returned element and was throwing an error. I push it back up a level and it seemed to be resolved. I also rearranged the card format to remove an h3 and h4 tag from the inside of a p tag. For the interactive map, I removed some meta elements of the parsed HTML that was not necessary for load or operation such as a head and body tag that were throwing errors. 